### PR TITLE
text typo + proper rendering of the screen's bottom bar

### DIFF
--- a/app/src/main/java/in/eswarm/narada/launch/LaunchActivity.kt
+++ b/app/src/main/java/in/eswarm/narada/launch/LaunchActivity.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowCompat.*
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -28,7 +30,8 @@ class LaunchActivity : ComponentActivity() {
     private val mainScope = MainScope()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        //enableEdgeToEdge() this does not go well with system navigation bottom bar
+        setDecorFitsSystemWindows(window, true)
 
         NotificationUtil.createNotificationChannel(this)
         mainScope.launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="username">Username</string>
     <string name="password">Password</string>
     <string name="enable_auth">"Enable Authentication"</string>
-    <string name="ws_path_title">Webocket Path</string>
+    <string name="ws_path_title">Websocket Path</string>
     <string name="path">Path</string>
     <string name="ws_port_title">"Websocket Port"</string>
     <string name="enable_ws_title">"Enable Websocket"</string>


### PR DESCRIPTION
text typo + proper rendering of the screen's bottom bar in situations when system navigation bottom bar is being used - at least on my phone